### PR TITLE
Rename async to async_req, add support for Python 3.7

### DIFF
--- a/signrequest_client/api/api_tokens_api.py
+++ b/signrequest_client/api/api_tokens_api.py
@@ -38,18 +38,18 @@ class ApiTokensApi(object):
 
         You can create an API token in the [team api settings page](/#/teams). It is also possible to get or create a token using the REST api with your login credentials.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.api_tokens_create(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.api_tokens_create(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param AuthToken data: (required)
         :return: AuthToken
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.api_tokens_create_with_http_info(data, **kwargs)  # noqa: E501
         else:
             (data) = self.api_tokens_create_with_http_info(data, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ApiTokensApi(object):
 
         You can create an API token in the [team api settings page](/#/teams). It is also possible to get or create a token using the REST api with your login credentials.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.api_tokens_create_with_http_info(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.api_tokens_create_with_http_info(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param AuthToken data: (required)
         :return: AuthToken
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ApiTokensApi(object):
         """
 
         all_params = ['data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ApiTokensApi(object):
             files=local_var_files,
             response_type='AuthToken',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,18 +137,18 @@ class ApiTokensApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.api_tokens_delete(key, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.api_tokens_delete(key, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str key: A unique value identifying this api token. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.api_tokens_delete_with_http_info(key, **kwargs)  # noqa: E501
         else:
             (data) = self.api_tokens_delete_with_http_info(key, **kwargs)  # noqa: E501
@@ -159,11 +159,11 @@ class ApiTokensApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.api_tokens_delete_with_http_info(key, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.api_tokens_delete_with_http_info(key, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str key: A unique value identifying this api token. (required)
         :return: None
                  If the method is called asynchronously,
@@ -171,7 +171,7 @@ class ApiTokensApi(object):
         """
 
         all_params = ['key']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class ApiTokensApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -236,11 +236,11 @@ class ApiTokensApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.api_tokens_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.api_tokens_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :return: InlineResponse200
@@ -248,7 +248,7 @@ class ApiTokensApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.api_tokens_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.api_tokens_list_with_http_info(**kwargs)  # noqa: E501
@@ -259,11 +259,11 @@ class ApiTokensApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.api_tokens_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.api_tokens_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :return: InlineResponse200
@@ -272,7 +272,7 @@ class ApiTokensApi(object):
         """
 
         all_params = ['page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -324,7 +324,7 @@ class ApiTokensApi(object):
             files=local_var_files,
             response_type='InlineResponse200',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -335,18 +335,18 @@ class ApiTokensApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.api_tokens_read(key, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.api_tokens_read(key, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str key: A unique value identifying this api token. (required)
         :return: AuthToken
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.api_tokens_read_with_http_info(key, **kwargs)  # noqa: E501
         else:
             (data) = self.api_tokens_read_with_http_info(key, **kwargs)  # noqa: E501
@@ -357,11 +357,11 @@ class ApiTokensApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.api_tokens_read_with_http_info(key, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.api_tokens_read_with_http_info(key, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str key: A unique value identifying this api token. (required)
         :return: AuthToken
                  If the method is called asynchronously,
@@ -369,7 +369,7 @@ class ApiTokensApi(object):
         """
 
         all_params = ['key']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -423,7 +423,7 @@ class ApiTokensApi(object):
             files=local_var_files,
             response_type='AuthToken',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/document_attachments_api.py
+++ b/signrequest_client/api/document_attachments_api.py
@@ -38,18 +38,18 @@ class DocumentAttachmentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.document_attachments_create(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.document_attachments_create(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param DocumentAttachment data: (required)
         :return: DocumentAttachment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.document_attachments_create_with_http_info(data, **kwargs)  # noqa: E501
         else:
             (data) = self.document_attachments_create_with_http_info(data, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class DocumentAttachmentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.document_attachments_create_with_http_info(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.document_attachments_create_with_http_info(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param DocumentAttachment data: (required)
         :return: DocumentAttachment
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class DocumentAttachmentsApi(object):
         """
 
         all_params = ['data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class DocumentAttachmentsApi(object):
             files=local_var_files,
             response_type='DocumentAttachment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class DocumentAttachmentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.document_attachments_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.document_attachments_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str document__uuid: 
         :param str document__external_id: 
         :param str created: 
@@ -152,7 +152,7 @@ class DocumentAttachmentsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.document_attachments_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.document_attachments_list_with_http_info(**kwargs)  # noqa: E501
@@ -163,11 +163,11 @@ class DocumentAttachmentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.document_attachments_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.document_attachments_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str document__uuid: 
         :param str document__external_id: 
         :param str created: 
@@ -179,7 +179,7 @@ class DocumentAttachmentsApi(object):
         """
 
         all_params = ['document__uuid', 'document__external_id', 'created', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class DocumentAttachmentsApi(object):
             files=local_var_files,
             response_type='InlineResponse2001',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,18 +248,18 @@ class DocumentAttachmentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.document_attachments_read(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.document_attachments_read(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: DocumentAttachment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.document_attachments_read_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.document_attachments_read_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -270,11 +270,11 @@ class DocumentAttachmentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.document_attachments_read_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.document_attachments_read_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: DocumentAttachment
                  If the method is called asynchronously,
@@ -282,7 +282,7 @@ class DocumentAttachmentsApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class DocumentAttachmentsApi(object):
             files=local_var_files,
             response_type='DocumentAttachment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/documents_api.py
+++ b/signrequest_client/api/documents_api.py
@@ -38,18 +38,18 @@ class DocumentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_create(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_create(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param Document data: (required)
         :return: Document
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.documents_create_with_http_info(data, **kwargs)  # noqa: E501
         else:
             (data) = self.documents_create_with_http_info(data, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class DocumentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_create_with_http_info(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_create_with_http_info(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param Document data: (required)
         :return: Document
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class DocumentsApi(object):
         """
 
         all_params = ['data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class DocumentsApi(object):
             files=local_var_files,
             response_type='Document',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,18 +137,18 @@ class DocumentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_delete(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_delete(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.documents_delete_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.documents_delete_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -159,11 +159,11 @@ class DocumentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_delete_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_delete_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: None
                  If the method is called asynchronously,
@@ -171,7 +171,7 @@ class DocumentsApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class DocumentsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -236,11 +236,11 @@ class DocumentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str external_id: 
         :param str signrequest__who: 
         :param str signrequest__from_email: 
@@ -257,7 +257,7 @@ class DocumentsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.documents_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.documents_list_with_http_info(**kwargs)  # noqa: E501
@@ -268,11 +268,11 @@ class DocumentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str external_id: 
         :param str signrequest__who: 
         :param str signrequest__from_email: 
@@ -290,7 +290,7 @@ class DocumentsApi(object):
         """
 
         all_params = ['external_id', 'signrequest__who', 'signrequest__from_email', 'status', 'user__email', 'user__first_name', 'user__last_name', 'created', 'modified', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -360,7 +360,7 @@ class DocumentsApi(object):
             files=local_var_files,
             response_type='InlineResponse2003',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -371,18 +371,18 @@ class DocumentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_read(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_read(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: Document
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.documents_read_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.documents_read_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -393,11 +393,11 @@ class DocumentsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_read_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_read_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: Document
                  If the method is called asynchronously,
@@ -405,7 +405,7 @@ class DocumentsApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -459,7 +459,7 @@ class DocumentsApi(object):
             files=local_var_files,
             response_type='Document',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/documents_search_api.py
+++ b/signrequest_client/api/documents_search_api.py
@@ -38,11 +38,11 @@ class DocumentsSearchApi(object):
 
         Search interface for fast (autocomplete) searching of documents.  This can be useful to have your users search for a document in your interface.  Document names are tokenized on whitespace, hyphens and underscores to also match partial document names.  *Normal search:*  - ?**q**={{query}}  *Autocomplete search:*  - ?**autocomplete**={{partial query}}  *Search in document name:*  - ?**name**={{query}}  *Available (extra) filters:*  - ?**subdomain**={{ team_subdomain }} or use this endpoint with team_subdomain.signrequest.com (when not provided only personal documents are shown) - ?**signer_emails**={{ signer@email.com }} (will filter documents that an email needed to sign/approve) - ?**status**={{ si }} - ?**who**={{ mo }}  To include multiple values for a filter field separate the values with a pipe (|). For example to only search for completed documents use **status=se|vi** (sent and viewed).  *Pagination:*  - ?**page**={{ page_number: default 1 }} - ?**limit**={{ limit results: default 10, max 100 }}  *Format:*  By default json is returned, to export data as csv or xls use the format parameter.  - ?**format**=csv - ?**format**=xls  For csv and xls the data can also be exported with each signer on a separate row. In this mode also the signer inputs that have an *external_id* specified on a tag will be exported. All external_id's found will be exported as columns. To use this mode add the **signer_data** parameter.  - ?**format**=csv&**signer_data**=1 - ?**format**=xls&**signer_data**=1  Note that all documents are only ordered by **created** (newest first) when **q**, **autocomplete** or **name** are not used, else they are ordered by the strenght of the match.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_search_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_search_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :param str q: Normal search query
@@ -59,7 +59,7 @@ class DocumentsSearchApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.documents_search_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.documents_search_list_with_http_info(**kwargs)  # noqa: E501
@@ -70,11 +70,11 @@ class DocumentsSearchApi(object):
 
         Search interface for fast (autocomplete) searching of documents.  This can be useful to have your users search for a document in your interface.  Document names are tokenized on whitespace, hyphens and underscores to also match partial document names.  *Normal search:*  - ?**q**={{query}}  *Autocomplete search:*  - ?**autocomplete**={{partial query}}  *Search in document name:*  - ?**name**={{query}}  *Available (extra) filters:*  - ?**subdomain**={{ team_subdomain }} or use this endpoint with team_subdomain.signrequest.com (when not provided only personal documents are shown) - ?**signer_emails**={{ signer@email.com }} (will filter documents that an email needed to sign/approve) - ?**status**={{ si }} - ?**who**={{ mo }}  To include multiple values for a filter field separate the values with a pipe (|). For example to only search for completed documents use **status=se|vi** (sent and viewed).  *Pagination:*  - ?**page**={{ page_number: default 1 }} - ?**limit**={{ limit results: default 10, max 100 }}  *Format:*  By default json is returned, to export data as csv or xls use the format parameter.  - ?**format**=csv - ?**format**=xls  For csv and xls the data can also be exported with each signer on a separate row. In this mode also the signer inputs that have an *external_id* specified on a tag will be exported. All external_id's found will be exported as columns. To use this mode add the **signer_data** parameter.  - ?**format**=csv&**signer_data**=1 - ?**format**=xls&**signer_data**=1  Note that all documents are only ordered by **created** (newest first) when **q**, **autocomplete** or **name** are not used, else they are ordered by the strenght of the match.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.documents_search_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.documents_search_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :param str q: Normal search query
@@ -92,7 +92,7 @@ class DocumentsSearchApi(object):
         """
 
         all_params = ['page', 'limit', 'q', 'autocomplete', 'name', 'subdomain', 'signer_emails', 'status', 'who', 'format', 'signer_data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -162,7 +162,7 @@ class DocumentsSearchApi(object):
             files=local_var_files,
             response_type='InlineResponse2002',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/events_api.py
+++ b/signrequest_client/api/events_api.py
@@ -38,11 +38,11 @@ class EventsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.events_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.events_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str document__uuid: 
         :param str document__external_id: 
         :param str document__signrequest__who: 
@@ -63,7 +63,7 @@ class EventsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.events_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.events_list_with_http_info(**kwargs)  # noqa: E501
@@ -74,11 +74,11 @@ class EventsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.events_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.events_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str document__uuid: 
         :param str document__external_id: 
         :param str document__signrequest__who: 
@@ -100,7 +100,7 @@ class EventsApi(object):
         """
 
         all_params = ['document__uuid', 'document__external_id', 'document__signrequest__who', 'document__signrequest__from_email', 'document__status', 'document__user__email', 'document__user__first_name', 'document__user__last_name', 'delivered', 'delivered_on', 'timestamp', 'status', 'event_type', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -178,7 +178,7 @@ class EventsApi(object):
             files=local_var_files,
             response_type='InlineResponse2004',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -189,18 +189,18 @@ class EventsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.events_read(id, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.events_read(id, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int id: A unique integer value identifying this event. (required)
         :return: Event
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.events_read_with_http_info(id, **kwargs)  # noqa: E501
         else:
             (data) = self.events_read_with_http_info(id, **kwargs)  # noqa: E501
@@ -211,11 +211,11 @@ class EventsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.events_read_with_http_info(id, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.events_read_with_http_info(id, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int id: A unique integer value identifying this event. (required)
         :return: Event
                  If the method is called asynchronously,
@@ -223,7 +223,7 @@ class EventsApi(object):
         """
 
         all_params = ['id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -277,7 +277,7 @@ class EventsApi(object):
             files=local_var_files,
             response_type='Event',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/signrequest_quick_create_api.py
+++ b/signrequest_client/api/signrequest_quick_create_api.py
@@ -38,18 +38,18 @@ class SignrequestQuickCreateApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequest_quick_create_create(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequest_quick_create_create(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param SignRequestQuickCreate data: (required)
         :return: SignRequestQuickCreate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.signrequest_quick_create_create_with_http_info(data, **kwargs)  # noqa: E501
         else:
             (data) = self.signrequest_quick_create_create_with_http_info(data, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class SignrequestQuickCreateApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequest_quick_create_create_with_http_info(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequest_quick_create_create_with_http_info(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param SignRequestQuickCreate data: (required)
         :return: SignRequestQuickCreate
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class SignrequestQuickCreateApi(object):
         """
 
         all_params = ['data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class SignrequestQuickCreateApi(object):
             files=local_var_files,
             response_type='SignRequestQuickCreate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/signrequests_api.py
+++ b/signrequest_client/api/signrequests_api.py
@@ -38,18 +38,18 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_cancel_signrequest(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_cancel_signrequest(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: InlineResponse201
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.signrequests_cancel_signrequest_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.signrequests_cancel_signrequest_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_cancel_signrequest_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_cancel_signrequest_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: InlineResponse201
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class SignrequestsApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class SignrequestsApi(object):
             files=local_var_files,
             response_type='InlineResponse201',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,18 +137,18 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_create(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_create(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param SignRequest data: (required)
         :return: SignRequest
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.signrequests_create_with_http_info(data, **kwargs)  # noqa: E501
         else:
             (data) = self.signrequests_create_with_http_info(data, **kwargs)  # noqa: E501
@@ -159,11 +159,11 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_create_with_http_info(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_create_with_http_info(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param SignRequest data: (required)
         :return: SignRequest
                  If the method is called asynchronously,
@@ -171,7 +171,7 @@ class SignrequestsApi(object):
         """
 
         all_params = ['data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class SignrequestsApi(object):
             files=local_var_files,
             response_type='SignRequest',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -236,11 +236,11 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str who: 
         :param str from_email: 
         :param int page: A page number within the paginated result set.
@@ -250,7 +250,7 @@ class SignrequestsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.signrequests_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.signrequests_list_with_http_info(**kwargs)  # noqa: E501
@@ -261,11 +261,11 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str who: 
         :param str from_email: 
         :param int page: A page number within the paginated result set.
@@ -276,7 +276,7 @@ class SignrequestsApi(object):
         """
 
         all_params = ['who', 'from_email', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -332,7 +332,7 @@ class SignrequestsApi(object):
             files=local_var_files,
             response_type='InlineResponse2005',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -343,18 +343,18 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_read(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_read(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: SignRequest
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.signrequests_read_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.signrequests_read_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -365,11 +365,11 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_read_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_read_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: SignRequest
                  If the method is called asynchronously,
@@ -377,7 +377,7 @@ class SignrequestsApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -431,7 +431,7 @@ class SignrequestsApi(object):
             files=local_var_files,
             response_type='SignRequest',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -442,18 +442,18 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_resend_signrequest_email(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_resend_signrequest_email(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: InlineResponse2011
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.signrequests_resend_signrequest_email_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.signrequests_resend_signrequest_email_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -464,11 +464,11 @@ class SignrequestsApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.signrequests_resend_signrequest_email_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.signrequests_resend_signrequest_email_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: InlineResponse2011
                  If the method is called asynchronously,
@@ -476,7 +476,7 @@ class SignrequestsApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -530,7 +530,7 @@ class SignrequestsApi(object):
             files=local_var_files,
             response_type='InlineResponse2011',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/team_members_api.py
+++ b/signrequest_client/api/team_members_api.py
@@ -38,11 +38,11 @@ class TeamMembersApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.team_members_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.team_members_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str is_active: 
         :param str is_owner: 
         :param str is_admin: 
@@ -56,7 +56,7 @@ class TeamMembersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.team_members_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.team_members_list_with_http_info(**kwargs)  # noqa: E501
@@ -67,11 +67,11 @@ class TeamMembersApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.team_members_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.team_members_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str is_active: 
         :param str is_owner: 
         :param str is_admin: 
@@ -86,7 +86,7 @@ class TeamMembersApi(object):
         """
 
         all_params = ['is_active', 'is_owner', 'is_admin', 'user__email', 'user__first_name', 'user__last_name', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -150,7 +150,7 @@ class TeamMembersApi(object):
             files=local_var_files,
             response_type='InlineResponse2006',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -161,18 +161,18 @@ class TeamMembersApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.team_members_read(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.team_members_read(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: TeamMember
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.team_members_read_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.team_members_read_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -183,11 +183,11 @@ class TeamMembersApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.team_members_read_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.team_members_read_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: TeamMember
                  If the method is called asynchronously,
@@ -195,7 +195,7 @@ class TeamMembersApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -249,7 +249,7 @@ class TeamMembersApi(object):
             files=local_var_files,
             response_type='TeamMember',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/teams_api.py
+++ b/signrequest_client/api/teams_api.py
@@ -38,18 +38,18 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_create(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_create(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param Team data: (required)
         :return: Team
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.teams_create_with_http_info(data, **kwargs)  # noqa: E501
         else:
             (data) = self.teams_create_with_http_info(data, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_create_with_http_info(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_create_with_http_info(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param Team data: (required)
         :return: Team
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class TeamsApi(object):
         """
 
         all_params = ['data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class TeamsApi(object):
             files=local_var_files,
             response_type='Team',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_invite_member(subdomain, data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_invite_member(subdomain, data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str subdomain: (required)
         :param InviteMember data: (required)
         :return: InviteMember
@@ -149,7 +149,7 @@ class TeamsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.teams_invite_member_with_http_info(subdomain, data, **kwargs)  # noqa: E501
         else:
             (data) = self.teams_invite_member_with_http_info(subdomain, data, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_invite_member_with_http_info(subdomain, data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_invite_member_with_http_info(subdomain, data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str subdomain: (required)
         :param InviteMember data: (required)
         :return: InviteMember
@@ -173,7 +173,7 @@ class TeamsApi(object):
         """
 
         all_params = ['subdomain', 'data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class TeamsApi(object):
             files=local_var_files,
             response_type='InviteMember',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :return: InlineResponse2007
@@ -256,7 +256,7 @@ class TeamsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.teams_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.teams_list_with_http_info(**kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :return: InlineResponse2007
@@ -280,7 +280,7 @@ class TeamsApi(object):
         """
 
         all_params = ['page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -332,7 +332,7 @@ class TeamsApi(object):
             files=local_var_files,
             response_type='InlineResponse2007',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -343,11 +343,11 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_partial_update(subdomain, data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_partial_update(subdomain, data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str subdomain: (required)
         :param Team data: (required)
         :return: Team
@@ -355,7 +355,7 @@ class TeamsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.teams_partial_update_with_http_info(subdomain, data, **kwargs)  # noqa: E501
         else:
             (data) = self.teams_partial_update_with_http_info(subdomain, data, **kwargs)  # noqa: E501
@@ -366,11 +366,11 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_partial_update_with_http_info(subdomain, data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_partial_update_with_http_info(subdomain, data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str subdomain: (required)
         :param Team data: (required)
         :return: Team
@@ -379,7 +379,7 @@ class TeamsApi(object):
         """
 
         all_params = ['subdomain', 'data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -439,7 +439,7 @@ class TeamsApi(object):
             files=local_var_files,
             response_type='Team',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -450,18 +450,18 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_read(subdomain, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_read(subdomain, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str subdomain: (required)
         :return: Team
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.teams_read_with_http_info(subdomain, **kwargs)  # noqa: E501
         else:
             (data) = self.teams_read_with_http_info(subdomain, **kwargs)  # noqa: E501
@@ -472,11 +472,11 @@ class TeamsApi(object):
 
         Required fields are **name** and **subdomain** where the subdomain is globally unique. Use **POST** to create a Team. To update a field on a Team use **PATCH**.  To use the API on behalf of a particular team change the endpoint to: *https://**{{ subdomain }}**.signrequest.com/api/v1/...*  To invite new team members you can use **POST** {\"email\":\"**email-of-member-to-invite@example.com**\",\"is_admin\":false,\"is_owner\":false} to: *https://signrequest.com/api/v1/teams/**{{ subdomain }}**/invite_member/*  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.teams_read_with_http_info(subdomain, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.teams_read_with_http_info(subdomain, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str subdomain: (required)
         :return: Team
                  If the method is called asynchronously,
@@ -484,7 +484,7 @@ class TeamsApi(object):
         """
 
         all_params = ['subdomain']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -538,7 +538,7 @@ class TeamsApi(object):
             files=local_var_files,
             response_type='Team',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/templates_api.py
+++ b/signrequest_client/api/templates_api.py
@@ -38,11 +38,11 @@ class TemplatesApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.templates_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.templates_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :return: InlineResponse2008
@@ -50,7 +50,7 @@ class TemplatesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.templates_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.templates_list_with_http_info(**kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class TemplatesApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.templates_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.templates_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :return: InlineResponse2008
@@ -74,7 +74,7 @@ class TemplatesApi(object):
         """
 
         all_params = ['page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class TemplatesApi(object):
             files=local_var_files,
             response_type='InlineResponse2008',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,18 +137,18 @@ class TemplatesApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.templates_read(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.templates_read(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: Template
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.templates_read_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.templates_read_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -159,11 +159,11 @@ class TemplatesApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.templates_read_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.templates_read_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: Template
                  If the method is called asynchronously,
@@ -171,7 +171,7 @@ class TemplatesApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class TemplatesApi(object):
             files=local_var_files,
             response_type='Template',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api/webhooks_api.py
+++ b/signrequest_client/api/webhooks_api.py
@@ -38,18 +38,18 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_create(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_create(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param WebhookSubscription data: (required)
         :return: WebhookSubscription
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.webhooks_create_with_http_info(data, **kwargs)  # noqa: E501
         else:
             (data) = self.webhooks_create_with_http_info(data, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_create_with_http_info(data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_create_with_http_info(data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param WebhookSubscription data: (required)
         :return: WebhookSubscription
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type='WebhookSubscription',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,18 +137,18 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_delete(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_delete(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.webhooks_delete_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.webhooks_delete_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -159,11 +159,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_delete_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_delete_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: None
                  If the method is called asynchronously,
@@ -171,7 +171,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -236,11 +236,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_list(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_list(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :return: InlineResponse2009
@@ -248,7 +248,7 @@ class WebhooksApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.webhooks_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.webhooks_list_with_http_info(**kwargs)  # noqa: E501
@@ -259,11 +259,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_list_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param int page: A page number within the paginated result set.
         :param int limit: Number of results to return per page.
         :return: InlineResponse2009
@@ -272,7 +272,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -324,7 +324,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type='InlineResponse2009',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -335,11 +335,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_partial_update(uuid, data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_partial_update(uuid, data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :param WebhookSubscription data: (required)
         :return: WebhookSubscription
@@ -347,7 +347,7 @@ class WebhooksApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.webhooks_partial_update_with_http_info(uuid, data, **kwargs)  # noqa: E501
         else:
             (data) = self.webhooks_partial_update_with_http_info(uuid, data, **kwargs)  # noqa: E501
@@ -358,11 +358,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_partial_update_with_http_info(uuid, data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_partial_update_with_http_info(uuid, data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :param WebhookSubscription data: (required)
         :return: WebhookSubscription
@@ -371,7 +371,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['uuid', 'data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -431,7 +431,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type='WebhookSubscription',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -442,18 +442,18 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_read(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_read(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: WebhookSubscription
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.webhooks_read_with_http_info(uuid, **kwargs)  # noqa: E501
         else:
             (data) = self.webhooks_read_with_http_info(uuid, **kwargs)  # noqa: E501
@@ -464,11 +464,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_read_with_http_info(uuid, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_read_with_http_info(uuid, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :return: WebhookSubscription
                  If the method is called asynchronously,
@@ -476,7 +476,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['uuid']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -530,7 +530,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type='WebhookSubscription',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -541,11 +541,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_update(uuid, data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_update(uuid, data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :param WebhookSubscription data: (required)
         :return: WebhookSubscription
@@ -553,7 +553,7 @@ class WebhooksApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.webhooks_update_with_http_info(uuid, data, **kwargs)  # noqa: E501
         else:
             (data) = self.webhooks_update_with_http_info(uuid, data, **kwargs)  # noqa: E501
@@ -564,11 +564,11 @@ class WebhooksApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.webhooks_update_with_http_info(uuid, data, async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.webhooks_update_with_http_info(uuid, data, async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str uuid: (required)
         :param WebhookSubscription data: (required)
         :return: WebhookSubscription
@@ -577,7 +577,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['uuid', 'data']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -637,7 +637,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type='WebhookSubscription',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/signrequest_client/api_client.py
+++ b/signrequest_client/api_client.py
@@ -274,7 +274,7 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None,
+                 response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
@@ -294,7 +294,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async bool: execute request asynchronously
+        :param async_req bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,
@@ -313,7 +313,7 @@ class ApiClient(object):
             If parameter async is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not async_req:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,


### PR DESCRIPTION
Implements fixes outlined here:

https://github.com/swagger-api/swagger-codegen/pull/8401